### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a static Astro portfolio/blog site. No databases, backend services, or Docker containers are required.
+
+### Node version
+
+The project requires **Node.js v20.17.0** (specified in `.nvmrc`). Use `nvm use` to activate it.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm install` |
+| Dev server | `npm run dev` (serves on `http://localhost:4321`, binds to `--host`) |
+| Build | `npm run build` (static output in `dist/`) |
+| Lint / format | `npx prettier --check "src/**/*.{astro,js,ts,tsx,md,mdx,css}"` |
+
+There is no dedicated `lint` or `test` npm script; Prettier is the only code-quality tool configured.
+
+### Caveats
+
+- The dev server uses `astro dev --host`, which binds to `0.0.0.0:4321`.
+- Prettier reports pre-existing formatting issues in the repo (`src/content/projects/easyedit.md`, `src/env.d.ts`). These are not regressions.
+- Blog/project content lives in `src/content/` as Markdown/MDX files managed by Astro Content Collections.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents, including:

- Node.js version requirement (v20.17.0 per `.nvmrc`)
- Key commands table (install, dev, build, lint)
- Non-obvious caveats (host binding, pre-existing Prettier issues, content collection location)

### Demo

<a href="https://cursor.com/agents/bc-bf48e83f-5639-44a4-9498-097afadb3e41/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_astro_portfolio_site.mp4"><img src="https://cursor.com/artifacts/c/art-004ad3b5-dc94-4c5a-8b54-c1bae81469ea" alt="demo_astro_portfolio_site.mp4" /></a>

Site running in dev mode — homepage, blog, projects, and dark mode toggle all working.

![Homepage in light mode](https://cursor.com/artifacts/c/art-98c6593a-05f9-49cc-98dc-633dff027919)
![Project page in dark mode](https://cursor.com/artifacts/c/art-bf9987c7-c96e-4bd4-b31a-6106aa633e90)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf48e83f-5639-44a4-9498-097afadb3e41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf48e83f-5639-44a4-9498-097afadb3e41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

